### PR TITLE
Fixed up business logic in build/send

### DIFF
--- a/client/rest/types.go
+++ b/client/rest/types.go
@@ -60,12 +60,13 @@ type CreateKeyResponse struct {
 // many fields so it would be nice to figure out all the invalid
 // inputs and report them back to the caller, in one shot.
 type SendInput struct {
-	Fees     *coin.Coin `json:"amount"`
+	Fees     *coin.Coin `json:"fees"`
 	Multi    bool       `json:"multi,omitempty"`
 	Sequence uint32     `json:"sequence"`
 
-	To   *basecoin.Actor `json:"to"`
-	From *basecoin.Actor `json:"from"`
+	To     *basecoin.Actor `json:"to"`
+	From   *basecoin.Actor `json:"from"`
+	Amount coin.Coins      `json:"amount"`
 }
 
 // Validators


### PR DESCRIPTION
This should work to test it:

```
curl -XPOST localhost:8998/build/send -d '{"from": {"app": "sigs", "address": "0EFF929AA4A6D561FC53C00A9F878B929CAF3040"}, "to": {"app": "sigs", "address": "84ABEBE99C5A4E81357BA3516EDDDC484F4288F1"}, "amount": [{"denom": "atom", "amount": 12345}], "sequence": 1}'
```

You can check this and make any cleanup needed.

I think this is just me being unclear on the meaning of all the stuff in the tx, and easier to write in code than english.  Other than that, looks good and looking forward to testing it.